### PR TITLE
update gempath to take in a string instead of an array

### DIFF
--- a/bin/spring
+++ b/bin/spring
@@ -8,7 +8,7 @@ unless defined?(Spring)
   require 'bundler'
 
   if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq }
+    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(File::PATH_SEPARATOR) }
     gem 'spring', match[1]
     require 'spring/binstub'
   end


### PR DESCRIPTION
Fixes this error: 
Array values in the parameter to `Gem.paths=` are deprecated.
Please use a String or nil.
An Array ({"GEM_PATH"=>["/Users/Apple/.rvm/gems/ruby-2.4.1", "/Users/Apple/.rvm/gems/ruby-2.4.1@global"]}) was passed in from bin/rails:3:in `load'